### PR TITLE
filter out aces with empty permissions

### DIFF
--- a/conductor-client/src/main/kotlin/com/openlattice/authorization/HazelcastAuthorizationService.kt
+++ b/conductor-client/src/main/kotlin/com/openlattice/authorization/HazelcastAuthorizationService.kt
@@ -417,7 +417,7 @@ class HazelcastAuthorizationService(
     @Timed
     override fun getAllSecurableObjectPermissions(key: AclKey): Acl {
         val acesWithPermissions = aces.entrySet(hasAclKey(key))
-                .filterNot { it.value.isEmpty() }
+                .filter { it.value.isNotEmpty() }
                 .map { Ace(it.key.principal, it.value.permissions) }
                 .toSet()
 
@@ -427,7 +427,7 @@ class HazelcastAuthorizationService(
     @Timed
     override fun getAllSecurableObjectPermissions(keys: Set<AclKey>): Set<Acl> {
         return aces.entrySet(hasAnyAclKeys(keys))
-                .filterNot { it.value.isEmpty() }
+                .filter { it.value.isNotEmpty() }
                 .groupBy { it.key.aclKey }
                 .mapTo(mutableSetOf()) { entry ->
                     Acl(entry.key, entry.value.mapTo(mutableSetOf()) { Ace(it.key.principal, it.value.permissions) })

--- a/conductor-client/src/main/kotlin/com/openlattice/authorization/HazelcastAuthorizationService.kt
+++ b/conductor-client/src/main/kotlin/com/openlattice/authorization/HazelcastAuthorizationService.kt
@@ -417,6 +417,7 @@ class HazelcastAuthorizationService(
     @Timed
     override fun getAllSecurableObjectPermissions(key: AclKey): Acl {
         val acesWithPermissions = aces.entrySet(hasAclKey(key))
+                .filterNot { it.value.isEmpty() }
                 .map { Ace(it.key.principal, it.value.permissions) }
                 .toSet()
 
@@ -426,6 +427,7 @@ class HazelcastAuthorizationService(
     @Timed
     override fun getAllSecurableObjectPermissions(keys: Set<AclKey>): Set<Acl> {
         return aces.entrySet(hasAnyAclKeys(keys))
+                .filterNot { it.value.isEmpty() }
                 .groupBy { it.key.aclKey }
                 .mapTo(mutableSetOf()) { entry ->
                     Acl(entry.key, entry.value.mapTo(mutableSetOf()) { Ace(it.key.principal, it.value.permissions) })


### PR DESCRIPTION
Aces with empty permissions are effectively the same as not having any permissions, but the ace object still exists and the API still returns these objects. It seems unnecessary for the API to return aces with empty permissions.

As far as I can tell, the only callers of `getAllSecurableObjectPermissions` are `PermissionsController`, which is what this change is intended for, and `AuditRecordEntitySetsManager`, which I'm not sure if this change will have an adverse impact on:

https://github.com/openlattice/openlattice/blob/develop/conductor-client/src/main/kotlin/com/openlattice/auditing/AuditRecordEntitySetsManager.kt#L206

https://github.com/openlattice/openlattice/blob/develop/conductor-client/src/main/kotlin/com/openlattice/auditing/AuditRecordEntitySetsManager.kt#L327

https://github.com/openlattice/openlattice/blob/develop/conductor-client/src/main/kotlin/com/openlattice/auditing/AuditRecordEntitySetsManager.kt#L331

https://github.com/openlattice/openlattice/blob/develop/conductor-client/src/main/kotlin/com/openlattice/auditing/AuditRecordEntitySetsManager.kt#L337

I'm also not entirely sure if this is the correct level in which to be making this change. Perhaps I should do this in `PermissionsController`, or add a boolean query parameter to the request to optionally do the filter. Thoughts?