### PR TITLE
allow org members to remove themselves

### DIFF
--- a/api/src/main/kotlin/com/openlattice/organization/OrganizationsApi.kt
+++ b/api/src/main/kotlin/com/openlattice/organization/OrganizationsApi.kt
@@ -273,9 +273,7 @@ interface OrganizationsApi {
     @GET(BASE + ID_PATH + PRINCIPALS + MEMBERS)
     fun getMembers(@Path(ID) organizationId: UUID): Iterable<OrganizationMember>
 
-    @GET(
-            BASE + PRINCIPALS + MEMBERS + COUNT
-    )
+    @GET(BASE + PRINCIPALS + MEMBERS + COUNT)
     fun getMemberCountForOrganizations(@Body organizationIds: Set<UUID>): Map<UUID, Int>
 
     @GET(BASE + PRINCIPALS + ROLES + COUNT)

--- a/api/src/main/kotlin/com/openlattice/organization/OrganizationsApi.kt
+++ b/api/src/main/kotlin/com/openlattice/organization/OrganizationsApi.kt
@@ -281,22 +281,16 @@ interface OrganizationsApi {
     @GET(BASE + PRINCIPALS + ROLES + COUNT)
     fun getRoleCountForOrganizations(@Body organizationIds: Set<UUID>): Map<UUID, Int>
 
-    @PUT(
-            BASE + ID_PATH + PRINCIPALS + MEMBERS + USER_ID_PATH
-    )
+    @PUT(BASE + ID_PATH + PRINCIPALS + MEMBERS + USER_ID_PATH)
     fun addMember(
-            @Path(ID) organizationId: UUID, @Path(
-                    USER_ID
-            ) userId: String
+            @Path(ID) organizationId: UUID,
+            @Path(USER_ID) userId: String
     ): Void?
 
-    @DELETE(
-            BASE + ID_PATH + PRINCIPALS + MEMBERS + USER_ID_PATH
-    )
+    @DELETE(BASE + ID_PATH + PRINCIPALS + MEMBERS + USER_ID_PATH)
     fun removeMember(
-            @Path(ID) organizationId: UUID, @Path(
-                    USER_ID
-            ) userId: String
+            @Path(ID) organizationId: UUID,
+            @Path(USER_ID) userId: String
     ): Void?
 
     // Endpoints about roles

--- a/datastore/src/main/java/com/openlattice/datastore/apps/controllers/AppController.java
+++ b/datastore/src/main/java/com/openlattice/datastore/apps/controllers/AppController.java
@@ -201,7 +201,7 @@ public class AppController implements AppApi, AuthorizingComponent {
         Map<UUID, AppType> result = Maps.newHashMapWithExpectedSize(collectionTemplateTypeIds.size());
         collectionsManager.getAllEntityTypeCollections().forEach( collection -> {
             collection.getTemplate().forEach( templateType -> {
-                
+
                 if (collectionTemplateTypeIds.contains( templateType.getId() )) {
                     result.put( templateType.getId(), new AppType(
                             templateType.getId(),
@@ -234,7 +234,7 @@ public class AppController implements AppApi, AuthorizingComponent {
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE )
     public Map<UUID, AppTypeSetting> getOrganizationAppsByAppId(
-            @RequestParam( ORGANIZATION_ID ) UUID organizationId ) {
+            @PathVariable( ORGANIZATION_ID ) UUID organizationId ) {
         ensureOwnerAccess( new AclKey( organizationId ) );
         return appService.getOrganizationAppsByAppId( organizationId );
     }

--- a/datastore/src/main/kotlin/com/openlattice/organizations/controllers/OrganizationsController.kt
+++ b/datastore/src/main/kotlin/com/openlattice/organizations/controllers/OrganizationsController.kt
@@ -537,12 +537,11 @@ class OrganizationsController : AuthorizingComponent, OrganizationsApi {
             @PathVariable(OrganizationsApi.ID) organizationId: UUID,
             @PathVariable(OrganizationsApi.USER_ID) userId: String
     ): Void? {
-        val principal = Principal(PrincipalType.USER, userId)
         // allow caller to remove themselves from the org
-        if (Principals.getCurrentPrincipals().contains(principal).not()) {
+        if (Principals.getCurrentUser().id != userId) {
             ensureOwnerAccess(AclKey(organizationId))
         }
-        organizations.removeMembers(organizationId, ImmutableSet.of(principal))
+        organizations.removeMembers(organizationId, ImmutableSet.of(Principal(PrincipalType.USER, userId)))
         edms.revokeAllPrivilegesFromMember(organizationId, userId)
         return null
     }

--- a/datastore/src/main/kotlin/com/openlattice/organizations/controllers/OrganizationsController.kt
+++ b/datastore/src/main/kotlin/com/openlattice/organizations/controllers/OrganizationsController.kt
@@ -477,7 +477,7 @@ class OrganizationsController : AuthorizingComponent, OrganizationsApi {
             value = [OrganizationsApi.PRINCIPALS + OrganizationsApi.MEMBERS + OrganizationsApi.COUNT],
             consumes = [MediaType.APPLICATION_JSON_VALUE], produces = [MediaType.APPLICATION_JSON_VALUE]
     )
-    override fun getMemberCountForOrganizations(organizationIds: Set<UUID>): Map<UUID, Int> {
+    override fun getMemberCountForOrganizations(@RequestBody organizationIds: Set<UUID>): Map<UUID, Int> {
         val readPermissions = EnumSet.of(Permission.READ)
         accessCheck( organizationIds.associate { AclKey(it) to readPermissions } )
         return organizations.getMemberCountsForOrganizations(organizationIds)
@@ -488,7 +488,7 @@ class OrganizationsController : AuthorizingComponent, OrganizationsApi {
             value = [OrganizationsApi.PRINCIPALS + OrganizationsApi.ROLES + OrganizationsApi.COUNT],
             consumes = [MediaType.APPLICATION_JSON_VALUE], produces = [MediaType.APPLICATION_JSON_VALUE]
     )
-    override fun getRoleCountForOrganizations(organizationIds: Set<UUID>): Map<UUID, Int> {
+    override fun getRoleCountForOrganizations(@RequestBody organizationIds: Set<UUID>): Map<UUID, Int> {
         val readPermissions = EnumSet.of(Permission.READ)
         accessCheck( organizationIds.associate { AclKey(it) to readPermissions } )
         return organizations.getRoleCountsForOrganizations(organizationIds)

--- a/datastore/src/main/kotlin/com/openlattice/organizations/controllers/OrganizationsController.kt
+++ b/datastore/src/main/kotlin/com/openlattice/organizations/controllers/OrganizationsController.kt
@@ -537,12 +537,12 @@ class OrganizationsController : AuthorizingComponent, OrganizationsApi {
             @PathVariable(OrganizationsApi.ID) organizationId: UUID,
             @PathVariable(OrganizationsApi.USER_ID) userId: String
     ): Void? {
-        ensureOwnerAccess(AclKey(organizationId))
-        organizations.removeMembers(
-                organizationId, ImmutableSet.of(
-                Principal(PrincipalType.USER, userId)
-        )
-        )
+        val principal = Principal(PrincipalType.USER, userId)
+        // allow caller to remove themselves from the org
+        if (Principals.getCurrentPrincipals().contains(principal).not()) {
+            ensureOwnerAccess(AclKey(organizationId))
+        }
+        organizations.removeMembers(organizationId, ImmutableSet.of(principal))
         edms.revokeAllPrivilegesFromMember(organizationId, userId)
         return null
     }

--- a/rehearsal/src/test/java/com/openlattice/rehearsal/organization/OrganizationsControllerTest.kt
+++ b/rehearsal/src/test/java/com/openlattice/rehearsal/organization/OrganizationsControllerTest.kt
@@ -184,8 +184,8 @@ class OrganizationsControllerTest : MultipleAuthenticatedUsersBase() {
         val orgId = createOrganization().id
         OrganizationControllerCallHelper.addMemberToOrganization(orgId, user1.id)
         OrganizationControllerCallHelper.addMemberToOrganization(orgId, user2.id)
-        Assert.assertEquals(2, organizationsApi.getMembers(orgId).count())
-        Assert.assertEquals(2, organizationsApi.getMemberCountForOrganizations(setOf(orgId))[orgId])
+        Assert.assertEquals(3, organizationsApi.getMembers(orgId).count())
+        Assert.assertEquals(3, organizationsApi.getMemberCountForOrganizations(setOf(orgId))[orgId])
 
         loginAs("user1")
 
@@ -197,14 +197,14 @@ class OrganizationsControllerTest : MultipleAuthenticatedUsersBase() {
 
         // user 1 should be able to remove themselves
         OrganizationControllerCallHelper.removeMemberFromOrganization(orgId, user1.id)
-        Assert.assertEquals(1, organizationsApi.getMembers(orgId).count())
-        Assert.assertEquals(1, organizationsApi.getMemberCountForOrganizations(setOf(orgId))[orgId])
+        Assert.assertEquals(2, organizationsApi.getMembers(orgId).count())
+        Assert.assertEquals(2, organizationsApi.getMemberCountForOrganizations(setOf(orgId))[orgId])
 
         loginAs("user2")
 
         // user 2 should be able to remove themselves
         OrganizationControllerCallHelper.removeMemberFromOrganization(orgId, user2.id)
-        Assert.assertEquals(0, organizationsApi.getMembers(orgId).count())
-        Assert.assertEquals(0, organizationsApi.getMemberCountForOrganizations(setOf(orgId))[orgId])
+        Assert.assertEquals(1, organizationsApi.getMembers(orgId).count())
+        Assert.assertEquals(1, organizationsApi.getMemberCountForOrganizations(setOf(orgId))[orgId])
     }
 }

--- a/rehearsal/src/test/java/com/openlattice/rehearsal/organization/OrganizationsControllerTest.kt
+++ b/rehearsal/src/test/java/com/openlattice/rehearsal/organization/OrganizationsControllerTest.kt
@@ -200,7 +200,6 @@ class OrganizationsControllerTest : MultipleAuthenticatedUsersBase() {
         Assert.assertEquals(1, organizationsApi.getMembers(orgId).count())
         Assert.assertEquals(1, organizationsApi.getMemberCountForOrganizations(setOf(orgId))[orgId])
 
-
         loginAs("user2")
 
         // user 2 should be able to remove themselves


### PR DESCRIPTION
At the moment, only users with OWNER on the org are allowed to add / remove members. As such, an org member cannot "leave" the org. I think org members should be allowed to leave on their own discretion.

The changes in the api file are just formatting changes.