### PR TITLE
parallelize syncing organization databases

### DIFF
--- a/indexer/src/main/java/com/openlattice/indexing/pods/IndexerPostConfigurationServicesPod.java
+++ b/indexer/src/main/java/com/openlattice/indexing/pods/IndexerPostConfigurationServicesPod.java
@@ -230,6 +230,7 @@ public class IndexerPostConfigurationServicesPod {
     public BackgroundExternalDatabaseSyncingService backgroundExternalDatabaseUpdatingService() {
         return new BackgroundExternalDatabaseSyncingService(
                 hazelcastInstance,
+                executor,
                 edms(),
                 externalDatabasePermissioningService,
                 auditingManager,

--- a/indexer/src/main/kotlin/com/openlattice/BackgroundExternalDatabaseSyncingService.kt
+++ b/indexer/src/main/kotlin/com/openlattice/BackgroundExternalDatabaseSyncingService.kt
@@ -98,10 +98,6 @@ class BackgroundExternalDatabaseSyncingService(
             val timer = Stopwatch.createStarted()
             orgsBeingSynced.add(organizationId)
 
-            if (organizationId == UUID.fromString("ef691fe3-a8ce-45ed-bf2e-e4fa15499067")) {
-                Thread.sleep(10000L)
-            }
-
             logger.info("starting syncing organization database - org {}", organizationId)
 
             val databaseName = organizationDatabases[organizationId]?.name

--- a/indexer/src/main/kotlin/com/openlattice/BackgroundExternalDatabaseSyncingService.kt
+++ b/indexer/src/main/kotlin/com/openlattice/BackgroundExternalDatabaseSyncingService.kt
@@ -210,8 +210,6 @@ class BackgroundExternalDatabaseSyncingService(
     ): UUID {
         val newTableId = edms.createOrganizationExternalDatabaseTable(orgId, table)
 
-        organizationMetadataEntitySetsService.addDataset(orgId, table)
-
         //create audit entity set and audit permissions
         ares.createAuditEntitySetForExternalDBTable(table)
 
@@ -254,7 +252,6 @@ class BackgroundExternalDatabaseSyncingService(
 
         if (tableIdsToDelete.isNotEmpty()) {
             edms.deleteExternalTableObjects(tableIdsToDelete)
-            organizationMetadataEntitySetsService.deleteDatasets(orgId, tableIdsToDelete)
         }
 
 
@@ -268,7 +265,6 @@ class BackgroundExternalDatabaseSyncingService(
 
         if (columnIdsToDelete.isNotEmpty()) {
             edms.deleteExternalColumnObjects(orgId, columnIdsToDelete)
-            organizationMetadataEntitySetsService.deleteDatasetColumns(orgId, columnIdsToDelete)
         }
     }
 
@@ -322,12 +318,6 @@ class BackgroundExternalDatabaseSyncingService(
             table: ExternalTable
     ): Int {
         var totalSynced = 0
-
-        organizationMetadataEntitySetsService.addDatasetColumns(
-                table.organizationId,
-                edms.getExternalTable(columns.first().tableId),
-                columns
-        )
 
         columns.forEach { column ->
             edms.createOrganizationExternalDatabaseColumn(table.organizationId, column)

--- a/indexer/src/main/kotlin/com/openlattice/BackgroundExternalDatabaseSyncingService.kt
+++ b/indexer/src/main/kotlin/com/openlattice/BackgroundExternalDatabaseSyncingService.kt
@@ -78,7 +78,7 @@ class BackgroundExternalDatabaseSyncingService(
                 .filter { it != IdConstants.GLOBAL_ORGANIZATION_ID.id }
                 .shuffled()
                 .parallelStream()
-                .forEach { syncOrganizationDatabases(it) }
+                .forEach { syncOrganizationDatabase(it) }
             logger.info("Completed syncing database objects in {}", timer)
         } catch (ex: Exception) {
             logger.error("Failed while syncing external database metadata", ex)
@@ -87,10 +87,10 @@ class BackgroundExternalDatabaseSyncingService(
         }
     }
 
-    private fun syncOrganizationDatabases(organizationId: UUID) {
+    private fun syncOrganizationDatabase(organizationId: UUID) {
 
         if (orgsBeingSynced.contains(organizationId)) {
-            logger.info("syncing organization databases is in progress - org {}", organizationId)
+            logger.info("syncing organization database is in progress - org {}", organizationId)
             return
         }
 
@@ -98,7 +98,11 @@ class BackgroundExternalDatabaseSyncingService(
             val timer = Stopwatch.createStarted()
             orgsBeingSynced.add(organizationId)
 
-            logger.info("starting syncing organization databases - org {}", organizationId)
+            if (organizationId == UUID.fromString("ef691fe3-a8ce-45ed-bf2e-e4fa15499067")) {
+                Thread.sleep(10000L)
+            }
+
+            logger.info("starting syncing organization database - org {}", organizationId)
 
             val databaseName = organizationDatabases[organizationId]?.name
             if (databaseName == null) {
@@ -133,7 +137,7 @@ class BackgroundExternalDatabaseSyncingService(
             )
         }
         catch (e: Exception) {
-            logger.error("error syncing organization databases - org {}", organizationId, e)
+            logger.error("error syncing organization database - org {}", organizationId, e)
         }
         finally {
             orgsBeingSynced.remove(organizationId)


### PR DESCRIPTION
In this pull request, I'm attempting to parallelize syncing organization databases. To do this, I'm using the `ListeningExecutorService` from `AsyncPod` to submit the sync logic as a task to be executed by the executor.

To prevent syncing the same org multiple times, and potentially consuming all available threads when there's a long-running sync, I'm using a concurrent hash set, i.e. `ConcurrentHashMap.newKeySet()` to effectively "lock" an organization id. My hope is that using `ConcurrentHashMap` in this way will be thread safe and will ensure any given org is only being synced by one thread while allowing other orgs to be synced in parallel.

The core logic inside `syncOrganizationDatabase` has not changed. I've just moved it to be inside `executor.submit`, surrounded it with a try-catch, added the "locking" using the concurrent hash map, and added logging.

This pull request depends on https://github.com/geekbeast/rhizome/pull/356.