### PR TITLE
Feature/lattice 2892 collaboration api enhancements

### DIFF
--- a/api/src/main/kotlin/com/openlattice/collaborations/CollaborationsApi.kt
+++ b/api/src/main/kotlin/com/openlattice/collaborations/CollaborationsApi.kt
@@ -40,7 +40,7 @@ interface CollaborationsApi {
     /**
      * Gets [Collaboration] objects the caller has [Permission.READ] on with the provided ids.
      *
-     * @return a list of [Collaboration] objects
+     * @return a Map<K, V> where K is a collaboration id and V a [Collaboration] object
      */
     @GET(BASE)
     fun getCollaborations(@Query(ID_PARAM) ids: Set<UUID>): Map<UUID, Collaboration>
@@ -192,7 +192,7 @@ interface CollaborationsApi {
      * the caller has [Permission.READ] on.
      *
      * @param dataSetIds a set of data set ids
-     * @return Map<K, V> where K is a data set id and V is a list of [Collaboration] ids
+     * @return Map<K, V> where K is a data set id and V is a list of [Collaboration] objects
      */
     @POST(BASE + DATA_SETS_PATH)
     fun getCollaborationsWithDataSets(@Body dataSetIds: Set<UUID>): Map<UUID, List<Collaboration>>

--- a/api/src/main/kotlin/com/openlattice/collaborations/CollaborationsApi.kt
+++ b/api/src/main/kotlin/com/openlattice/collaborations/CollaborationsApi.kt
@@ -24,7 +24,7 @@ interface CollaborationsApi {
         const val COLLABORATION_ID_PATH = "/{$COLLABORATION_ID_PARAM}"
         const val DATA_SET_ID_PARAM = "dataSetId"
         const val DATA_SET_ID_PATH = "/{$DATA_SET_ID_PARAM}"
-        const val ID_PARAM = "id"
+        const val IDS_PARAM = "ids"
         const val ORGANIZATION_ID_PARAM = "organizationId"
         const val ORGANIZATION_ID_PATH = "/{$ORGANIZATION_ID_PARAM}"
     }
@@ -43,7 +43,7 @@ interface CollaborationsApi {
      * @return a Map<K, V> where K is a collaboration id and V a [Collaboration] object
      */
     @GET(BASE)
-    fun getCollaborations(@Query(ID_PARAM) ids: Set<UUID>): Map<UUID, Collaboration>
+    fun getCollaborations(@Query(IDS_PARAM) ids: Set<UUID>): Map<UUID, Collaboration>
 
     /**
      * Gets the [Collaboration] object with the given collaboration id. The caller must have [Permission.READ] on the

--- a/api/src/main/kotlin/com/openlattice/collaborations/CollaborationsApi.kt
+++ b/api/src/main/kotlin/com/openlattice/collaborations/CollaborationsApi.kt
@@ -14,6 +14,7 @@ interface CollaborationsApi {
         const val CONTROLLER = "/collaborations"
         const val BASE = SERVICE + CONTROLLER
 
+        const val ALL_PATH = "/all"
         const val DATABASE_PATH = "/database"
         const val DATA_SETS_PATH = "/datasets"
         const val ORGANIZATIONS_PATH = "/organizations"
@@ -23,6 +24,7 @@ interface CollaborationsApi {
         const val COLLABORATION_ID_PATH = "/{$COLLABORATION_ID_PARAM}"
         const val DATA_SET_ID_PARAM = "dataSetId"
         const val DATA_SET_ID_PATH = "/{$DATA_SET_ID_PARAM}"
+        const val ID_PARAM = "id"
         const val ORGANIZATION_ID_PARAM = "organizationId"
         const val ORGANIZATION_ID_PATH = "/{$ORGANIZATION_ID_PARAM}"
     }
@@ -32,8 +34,16 @@ interface CollaborationsApi {
      *
      * @return a list of [Collaboration] objects
      */
+    @GET(BASE + ALL_PATH)
+    fun getAllCollaborations(): Iterable<Collaboration>
+
+    /**
+     * Gets [Collaboration] objects the caller has [Permission.READ] on with the provided ids.
+     *
+     * @return a Map<K, V> where K is a collaboration id and V a [Collaboration] object
+     */
     @GET(BASE)
-    fun getCollaborations(): Iterable<Collaboration>
+    fun getCollaborations(@Query(ID_PARAM) ids: Set<UUID>): Map<UUID, Collaboration>
 
     /**
      * Gets the [Collaboration] object with the given collaboration id. The caller must have [Permission.READ] on the
@@ -185,5 +195,5 @@ interface CollaborationsApi {
      * @return Map<K, V> where K is a data set id and V is a list of [Collaboration] ids
      */
     @POST(BASE + DATA_SETS_PATH)
-    fun getCollaborationsWithDataSets(@Body dataSetIds: Set<UUID>): Map<UUID, List<UUID>>
+    fun getCollaborationsWithDataSets(@Body dataSetIds: Set<UUID>): Map<UUID, List<Collaboration>>
 }

--- a/datastore/src/main/kotlin/com/openlattice/collaborations/controllers/CollaborationsController.kt
+++ b/datastore/src/main/kotlin/com/openlattice/collaborations/controllers/CollaborationsController.kt
@@ -14,7 +14,7 @@ import com.openlattice.collaborations.CollaborationsApi.Companion.DATABASE_PATH
 import com.openlattice.collaborations.CollaborationsApi.Companion.DATA_SETS_PATH
 import com.openlattice.collaborations.CollaborationsApi.Companion.DATA_SET_ID_PARAM
 import com.openlattice.collaborations.CollaborationsApi.Companion.DATA_SET_ID_PATH
-import com.openlattice.collaborations.CollaborationsApi.Companion.ID_PARAM
+import com.openlattice.collaborations.CollaborationsApi.Companion.IDS_PARAM
 import com.openlattice.collaborations.CollaborationsApi.Companion.ORGANIZATIONS_PATH
 import com.openlattice.collaborations.CollaborationsApi.Companion.ORGANIZATION_ID_PARAM
 import com.openlattice.collaborations.CollaborationsApi.Companion.ORGANIZATION_ID_PATH
@@ -56,7 +56,7 @@ class CollaborationsController : AuthorizingComponent, CollaborationsApi {
             value = ["", "/"],
             produces = [MediaType.APPLICATION_JSON_VALUE]
     )
-    override fun getCollaborations(@RequestParam( ID_PARAM ) ids: Set<UUID>): Map<UUID, Collaboration> {
+    override fun getCollaborations(@RequestParam( IDS_PARAM ) ids: Set<UUID>): Map<UUID, Collaboration> {
         val authorizedCollaborationIds = getAllAuthorizedCollaborationIds().intersect(ids)
         return collaborationService.getCollaborations(authorizedCollaborationIds)
     }

--- a/datastore/src/main/kotlin/com/openlattice/collaborations/controllers/CollaborationsController.kt
+++ b/datastore/src/main/kotlin/com/openlattice/collaborations/controllers/CollaborationsController.kt
@@ -6,6 +6,7 @@ import com.openlattice.authorization.securable.SecurableObjectType
 import com.openlattice.collaborations.Collaboration
 import com.openlattice.collaborations.CollaborationService
 import com.openlattice.collaborations.CollaborationsApi
+import com.openlattice.collaborations.CollaborationsApi.Companion.ALL_PATH
 import com.openlattice.collaborations.CollaborationsApi.Companion.COLLABORATION_ID_PARAM
 import com.openlattice.collaborations.CollaborationsApi.Companion.COLLABORATION_ID_PATH
 import com.openlattice.collaborations.CollaborationsApi.Companion.CONTROLLER
@@ -13,6 +14,7 @@ import com.openlattice.collaborations.CollaborationsApi.Companion.DATABASE_PATH
 import com.openlattice.collaborations.CollaborationsApi.Companion.DATA_SETS_PATH
 import com.openlattice.collaborations.CollaborationsApi.Companion.DATA_SET_ID_PARAM
 import com.openlattice.collaborations.CollaborationsApi.Companion.DATA_SET_ID_PATH
+import com.openlattice.collaborations.CollaborationsApi.Companion.ID_PARAM
 import com.openlattice.collaborations.CollaborationsApi.Companion.ORGANIZATIONS_PATH
 import com.openlattice.collaborations.CollaborationsApi.Companion.ORGANIZATION_ID_PARAM
 import com.openlattice.collaborations.CollaborationsApi.Companion.ORGANIZATION_ID_PATH
@@ -41,12 +43,22 @@ class CollaborationsController : AuthorizingComponent, CollaborationsApi {
 
     @Timed
     @GetMapping(
-        value = ["", "/"],
+        value = [ALL_PATH],
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
-    override fun getCollaborations(): Iterable<Collaboration> {
+    override fun getAllCollaborations(): Iterable<Collaboration> {
         val authorizedCollaborationIds = getAllAuthorizedCollaborationIds()
         return collaborationService.getCollaborations(authorizedCollaborationIds).values
+    }
+
+    @Timed
+    @GetMapping(
+            value = ["", "/"],
+            produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    override fun getCollaborations(@RequestParam( ID_PARAM ) ids: Set<UUID>): Map<UUID, Collaboration> {
+        val authorizedCollaborationIds = getAllAuthorizedCollaborationIds().intersect(ids)
+        return collaborationService.getCollaborations(authorizedCollaborationIds)
     }
 
     @Timed
@@ -223,13 +235,13 @@ class CollaborationsController : AuthorizingComponent, CollaborationsApi {
         consumes = [MediaType.APPLICATION_JSON_VALUE],
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
-    override fun getCollaborationsWithDataSets(@RequestBody dataSetIds: Set<UUID>): Map<UUID, List<UUID>> {
+    override fun getCollaborationsWithDataSets(@RequestBody dataSetIds: Set<UUID>): Map<UUID, List<Collaboration>> {
         val authorizedDataSetIds = filterToAuthorizedIds(dataSetIds)
         val authorizedCollaborationIds = getAllAuthorizedCollaborationIds()
         return collaborationService.getCollaborationIdsWithProjectionsForTables(
             authorizedDataSetIds,
             authorizedCollaborationIds
-        )
+        ).mapValues { collaborationService.getCollaborations(it.value.toSet()).values.toList() }
     }
 
     private fun getAllAuthorizedCollaborationIds(): Set<UUID> {


### PR DESCRIPTION
- `getCollaborations` has been reworked to get Collaboration objects (READ) for each collaboration id provided
- `getAllCollaborations` gets all Collaboration objects the caller has READ permissions on (old getCollaborations behavior)
- `getCollaborationsWithDataSets` has been reworked to return Collaboration objects, instead of just their ids