### PR TITLE
Task/lattice 2973 linker memory

### DIFF
--- a/linker/README.md
+++ b/linker/README.md
@@ -5,7 +5,7 @@ Deep learning based entity resolution service.
 
 
 ## Setup
-1. ```LINKER_XMS```,```LINKER_XMX``` ```LINKER_OFFHEAP``` must be configured otherwise default values in gradle script will be used.
+1. ```LINKER_XMS```,```LINKER_XMX``` and ```LINKER_OFFHEAP``` must be configured otherwise default values in gradle script will be used.
 2. Ensure that linking.yaml, auth0.yaml, and auditing.yaml are configured correctly.
 
 

--- a/linker/README.md
+++ b/linker/README.md
@@ -5,7 +5,7 @@ Deep learning based entity resolution service.
 
 
 ## Setup
-1. ```LINKER_XMS``` and ```LINNKER_XMX``` must be configured otherwise default values in gradle script will be used.
+1. ```LINKER_XMS```,```LINKER_XMX``` ```LINKER_OFFHEAP``` must be configured otherwise default values in gradle script will be used.
 2. Ensure that linking.yaml, auth0.yaml, and auditing.yaml are configured correctly.
 
 

--- a/linker/build.gradle
+++ b/linker/build.gradle
@@ -178,6 +178,10 @@ dependencies {
         exclude module: 'guava'
     }
 
+    implementation("org.deeplearning4j:deeplearning4j-parallel-wrapper:${deeplearning4j}") {
+        exclude module: 'guava'
+    }
+
     implementation("org.nd4j:nd4j-native-platform:${deeplearning4j}") {
         exclude module: 'guava'
     }

--- a/linker/build.gradle
+++ b/linker/build.gradle
@@ -60,6 +60,7 @@ apply plugin: 'license-report'
 
 def LINKER_XMS = "$System.env.LINKER_XMS"
 def LINKER_XMX = "$System.env.LINKER_XMX"
+def LINKER_OFFHEAP = "$System.env.LINKER_OFFHEAP"
 def L_ARGS = "$System.env.LINKER_ARGS"
 def PARALLEL = "$System.env.PARALLELISM"
 def GC = "$System.env.GC"
@@ -69,7 +70,11 @@ if (LINKER_XMS == 'null' || LINKER_XMS == null || LINKER_XMS == "") {
 }
 
 if (LINKER_XMX == 'null' || LINKER_XMX == null || LINKER_XMX == "") {
-    LINKER_XMX = '-Xms4g'
+    LINKER_XMX = '-Xmx4g'
+}
+
+if (LINKER_OFFHEAP == 'null' || LINKER_OFFHEAP == null || LINKER_OFFHEAP == "") {
+    LINKER_OFFHEAP = '-Dorg.bytedeco.javacpp.maxbytes=2g'
 }
 
 if (L_ARGS == 'null' || L_ARGS == null || L_ARGS == "") {
@@ -91,7 +96,7 @@ java {
 }
 
 mainClassName = "com.openlattice.linking.Linker"
-applicationDefaultJvmArgs = [LINKER_XMS, LINKER_XMX, "-server", GC, PARALLEL]
+applicationDefaultJvmArgs = [LINKER_XMS, LINKER_XMX, LINKER_OFFHEAP, "-server", GC, PARALLEL]
 applicationDefaultJvmArgs += ["--add-modules", "java.se",
                               "--add-exports", "java.base/jdk.internal.ref=ALL-UNNAMED",
                               "--add-opens", "java.base/java.lang=ALL-UNNAMED",

--- a/linker/src/main/kotlin/com/openlattice/linking/matching/SocratesMatcher.kt
+++ b/linker/src/main/kotlin/com/openlattice/linking/matching/SocratesMatcher.kt
@@ -52,7 +52,7 @@ class SocratesMatcher(
         private val linkingFeedbackService: PostgresLinkingFeedbackService
 ) : Matcher {
 
-    private var localModel = ParallelInference.Builder(model)
+    private val localModel = ParallelInference.Builder(model)
                         .inferenceMode(InferenceMode.SEQUENTIAL)
                         // .batchLimit(32)
                         .workers(Runtime.getRuntime().availableProcessors())

--- a/linker/src/main/kotlin/com/openlattice/linking/matching/SocratesMatcher.kt
+++ b/linker/src/main/kotlin/com/openlattice/linking/matching/SocratesMatcher.kt
@@ -59,12 +59,7 @@ class SocratesMatcher(
                         .build()
 
     override fun updateMatchingModel(model: MultiLayerNetwork) {
-        localModel.shutdown()
-        localModel = ParallelInference.Builder(model)
-            .inferenceMode(InferenceMode.SEQUENTIAL)
-            // .batchLimit(32)
-            .workers(Runtime.getRuntime().availableProcessors())
-            .build()
+        localModel.updateModel(model)
     }
 
     /**

--- a/linker/src/main/kotlin/com/openlattice/linking/matching/SocratesMatcher.kt
+++ b/linker/src/main/kotlin/com/openlattice/linking/matching/SocratesMatcher.kt
@@ -203,7 +203,7 @@ class SocratesMatcher(
         val featureExtractionSW = sw.elapsed(TimeUnit.MILLISECONDS)
 
         // get scores from matrix
-        val scores = computeScore(localModel.get(), featureMatrix)
+        val scores = computeScore(localModel, featureMatrix)
 
         // collect and combine keys and scores
         val results = scores.zip(featureKeys).map {
@@ -226,7 +226,7 @@ class SocratesMatcher(
     }
 
     private fun computeScore(
-            model: MultiLayerNetwork,
+            model: ParallelInference,
             features: Array<DoubleArray>
     ): DoubleArray {
         val sw = Stopwatch.createStarted()
@@ -269,7 +269,7 @@ class SocratesMatcher(
     }
 }
 
-fun MultiLayerNetwork.getModelScore(features: Array<DoubleArray>): DoubleArray {
+fun ParallelInference.getModelScore(features: Array<DoubleArray>): DoubleArray {
     return try {
         output(Nd4j.create(features)).toDoubleVector()
     } catch (ex: Exception) {

--- a/linker/src/main/kotlin/com/openlattice/linking/matching/SocratesMatcher.kt
+++ b/linker/src/main/kotlin/com/openlattice/linking/matching/SocratesMatcher.kt
@@ -53,8 +53,7 @@ class SocratesMatcher(
 ) : Matcher {
 
     private val localModel = ParallelInference.Builder(model)
-                        .inferenceMode(InferenceMode.SEQUENTIAL)
-                        // .batchLimit(32)
+                        .inferenceMode(InferenceMode.INPLACE)
                         .workers(Runtime.getRuntime().availableProcessors())
                         .build()
 

--- a/linker/src/test/kotlin/com/openlattice/linking/LinkingScoringTest.kt
+++ b/linker/src/test/kotlin/com/openlattice/linking/LinkingScoringTest.kt
@@ -56,7 +56,7 @@ open class LinkingScoringTest {
 
             // compute score
             val cleanFeatures = arrayOf(distance.toDoubleArray())
-            val score = model.getModelScore(cleanFeatures ).get(0)
+            val score = localModel.getModelScore(cleanFeatures ).get(0)
             Assert.assertEquals(comparison.score, score, 0.00001)
 
         }

--- a/linker/src/test/kotlin/com/openlattice/linking/LinkingScoringTest.kt
+++ b/linker/src/test/kotlin/com/openlattice/linking/LinkingScoringTest.kt
@@ -7,6 +7,7 @@ import com.openlattice.linking.util.PersonMetric
 import com.openlattice.rhizome.hazelcast.DelegatedStringSet
 import org.apache.olingo.commons.api.edm.FullQualifiedName
 import org.deeplearning4j.nn.modelimport.keras.KerasModelImport
+import org.deeplearning4j.parallelism.ParallelInference
 import org.junit.Assert
 import org.junit.Test
 import org.nd4j.linalg.io.ClassPathResource
@@ -34,6 +35,7 @@ open class LinkingScoringTest {
         // load model
         val simpleMlp = ClassPathResource("model_2019-01-30.h5").file.path
         val model = KerasModelImport.importKerasSequentialModelAndWeights( simpleMlp )
+        val localModel = ParallelInference.Builder(model).build()
 
         // load input/output
         val configFile = ClassPathResource("scoringTest.yaml").file.path


### PR DESCRIPTION
 `SocratesMatcher` currently initialise with a copy of the model every time a new thread is started. These (copies of the) model actually live off heap according to dl4j’s documentation, and thus are not managed by the JVM’s gc. This can cause memory issues. 

Instead, wrap the model with `ParallelInference` and let dl4j manage the multi-threading.

EDIT: ```LINKER_OFFHEAP``` should be no more than half of ```LINKER_XMX```. Based on what I see on prod before, maybe something like ```LINKER_XMX=-Xmx50g```, ```LINKER_OFFHEAP=-Dorg.bytedeco.javacpp.maxbytes=20g``` should suffice.