### PR TITLE
Turning off atlas permissioning for entity sets

### DIFF
--- a/conductor-client/src/main/kotlin/com/openlattice/postgres/external/ExternalDatabasePermissioner.kt
+++ b/conductor-client/src/main/kotlin/com/openlattice/postgres/external/ExternalDatabasePermissioner.kt
@@ -259,7 +259,8 @@ class ExternalDatabasePermissioner(
             completedColumnAcls.add(Acl(internalIdAclKey, readAces))
         }
 
-        updateTablePermissions(action, SecurableObjectType.PropertyTypeInEntitySet, completedColumnAcls, completedColumnsById, TableType.VIEW)
+        logger.info("Permissioning for entity-sets in atlas currently disabled.")
+        //updateTablePermissions(action, SecurableObjectType.PropertyTypeInEntitySet, completedColumnAcls, completedColumnsById, TableType.VIEW)
     }
 
     /**


### PR DESCRIPTION
Currently there are no entity sets on atlas. Turning off atlas permissioning for entity sets to reduce confusing permissioner errors.